### PR TITLE
Redo workaround for build fail

### DIFF
--- a/ExampleFrontend/META-INF/MANIFEST.MF
+++ b/ExampleFrontend/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: ExampleFrontend;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Activator: examplefrontend.Activator
 Require-Bundle: org.eclipse.ui,
- org.eclipse.ui.workbench,
  org.eclipse.core.runtime,
  example.core
 Bundle-ActivationPolicy: lazy

--- a/ExampleFrontend/build.gradle.kts
+++ b/ExampleFrontend/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(project(":ExampleCore"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1114
+    implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
+    implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")
 }
 
 tasks {


### PR DESCRIPTION
This removes the previous addition of org.eclipse.ui.workbench to the
requirements in the manifest.mf and instead makes it a gradle dependency
which makes it possible to define the version and in general more flexible.